### PR TITLE
check that zip file exists

### DIFF
--- a/postgres/insert_gtfs.sh
+++ b/postgres/insert_gtfs.sh
@@ -7,6 +7,11 @@ fi
 
 export PGPASSWORD=$3
 
+if [ ! -f $1 ]; then
+    echo "File not found. Aborting."
+    exit -1
+fi
+
 mkdir -p /tmp/gtfs
 
 time unzip -o -d /tmp/gtfs $1


### PR DESCRIPTION
If the zip file doesn't exist, but /tmp/gtfs folder does (with old files), we print an error message but then move on to unnecessarily re-populating the DB with the old data that was there. This change will print an error message and abort.
Tested with a non-existing file and an existing file.