### PR TITLE
add gtfs_trips.trip_headsign, Fixes #51

### DIFF
--- a/postgres/insert_gtfs.sql
+++ b/postgres/insert_gtfs.sql
@@ -116,11 +116,12 @@ CREATE INDEX stops_town
 
 CREATE TABLE gtfs_trips
 (
-  route_id     INTEGER,
-  service_id   INTEGER,
-  trip_id      CHARACTER VARYING(50) NOT NULL,
-  direction_id INTEGER,
-  shape_id     INTEGER
+  route_id      INTEGER,
+  service_id    INTEGER,
+  trip_id       CHARACTER VARYING(50) NOT NULL,
+  trip_headsign TEXT,
+  direction_id  INTEGER,
+  shape_id      INTEGER
 );
 ALTER TABLE gtfs_trips
   OWNER TO obus;


### PR DESCRIPTION
See issue #51.
Tested with 2017-12-29 file from GTFS.
Verified that the new column is created properly.
After the change:
```
[snip]
********** importing trips **********
CREATE TABLE
Time: 2.051 ms
ALTER TABLE
Time: 0.834 ms
COPY 275259
Time: 1150.191 ms
ALTER TABLE
Time: 217.547 ms
CREATE INDEX
Time: 168.778 ms
CREATE INDEX
Time: 148.275 ms
CREATE INDEX
Time: 151.648 ms
CREATE INDEX
Time: 159.232 ms
[snip]
```
and
```
obus=> select count(*) from gtfs_trips;
 count  
--------
 275259
(1 row)
```