### PR TITLE
Handle new trip_headsign field, including quotations.

### DIFF
--- a/postgres/insert_gtfs.sql
+++ b/postgres/insert_gtfs.sql
@@ -119,14 +119,14 @@ CREATE TABLE gtfs_trips
   route_id      INTEGER,
   service_id    INTEGER,
   trip_id       CHARACTER VARYING(50) NOT NULL,
-  trip_headsign TEXT,
+  trip_headsign CHARACTER VARYING(50),
   direction_id  INTEGER,
   shape_id      INTEGER
 );
 ALTER TABLE gtfs_trips
   OWNER TO obus;
 
-\copy gtfs_trips from '/tmp/gtfs/trips.txt' DELIMITER ',' CSV HEADER;
+\copy gtfs_trips from '/tmp/gtfs/trips.txt' DELIMITER ',' QUOTE E'\b' CSV HEADER;
 
 
 ALTER TABLE gtfs_trips

--- a/postgres/insert_gtfs.sql
+++ b/postgres/insert_gtfs.sql
@@ -116,11 +116,12 @@ CREATE INDEX stops_town
 
 CREATE TABLE gtfs_trips
 (
-  route_id     INTEGER,
-  service_id   INTEGER,
-  trip_id      CHARACTER VARYING(50) NOT NULL,
-  direction_id INTEGER,
-  shape_id     INTEGER
+  route_id      INTEGER,
+  service_id    INTEGER,
+  trip_id       CHARACTER VARYING(50) NOT NULL,
+  trip_headsign TEXT,
+  direction_id  INTEGER,
+  shape_id      INTEGER
 );
 ALTER TABLE gtfs_trips
   OWNER TO obus;


### PR DESCRIPTION
Fixes for #51 and #53.
trips file loaded properly with no errors. Number of trips is as expected. Here is an example of a route with a headsign that contains quotation marks:

```
obus=> select * from gtfs_trips where route_id = '3159';
 route_id | service_id |     trip_id     |      trip_headsign      | direction_id | shape_id 
----------+------------+-----------------+-------------------------+--------------+----------
     3159 |   54618038 | 5036931_311217  | נס ציונה _ בית ספר חב"ד |            0 |    86320
     3159 |   54618048 | 5036931_010218  | נס ציונה _ בית ספר חב"ד |            0 |    86320
     3159 |   54618046 | 5036931_010118  | נס ציונה _ בית ספר חב"ד |            0 |    86320
     3159 |   54618047 | 30513740_310118 | נס ציונה _ בית ספר חב"ד |            0 |    86320
(4 rows)

```
