### PR TITLE
Adjust create_siri_csv_splunk to siri log v2

### DIFF
--- a/pipeline/create_siri_csv_splunk.py
+++ b/pipeline/create_siri_csv_splunk.py
@@ -65,12 +65,14 @@ def create_trip_df_v2(path, drop=['desc'],
               .assign(route_id = lambda x: x.route_id.astype(int))
               .assign(lat = lambda x: x.lat.astype(float))
               .assign(lon = lambda x: x.lon.astype(float)))
-    if add_date:
-        df = (df.assign(date = lambda x: x.data_frame_ref))
     
     df[['date_recorded', 'time_recorded']] = df.time_recorded.str.split('T', expand=True)
     df[['predicted_end_date', 'predicted_end_time']] = df.predicted_end_time.str.split('T', expand=True)
     df[['planned_start_date', 'planned_start_time']] = df.planned_start_time.str.split('T', expand=True)
+
+    if add_date:
+        df = (df.assign(date = lambda x: x.planned_start_date))
+        
     df = df[["timestamp", "agency_id",
                   "route_id", "route_short_name", "service_id",
                   "planned_start_date", "planned_start_time", "bus_id", "predicted_end_date", "predicted_end_time",

--- a/pipeline/create_siri_csv_splunk.py
+++ b/pipeline/create_siri_csv_splunk.py
@@ -48,18 +48,54 @@ def create_trip_df(path, drop=['timestamp', 'desc'],
 
     return df
 
+def create_trip_df_v2(path, drop=['desc'],
+                   add_date=True):
+    header = ["timestamp", "desc", "agency_id",
+              "route_id", "route_short_name", "service_id",
+              "planned_start_time", "bus_id", "predicted_end_time",
+              "time_recorded", "lat", "lon",
+              "data_frame_ref", "stop_point_ref", "vehicle_at_stop",
+              "log_version"]
+    df = pd.read_csv(path, header=None, error_bad_lines=False)
+    df.columns = header
+    if drop is not None:
+        df = df.drop(drop, axis=1)
+    df = (df.assign(agency_id = lambda x: x.agency_id.astype(int))
+              .assign(service_id = lambda x: x.service_id.astype(int))
+              .assign(route_id = lambda x: x.route_id.astype(int))
+              .assign(lat = lambda x: x.lat.astype(float))
+              .assign(lon = lambda x: x.lon.astype(float)))
+    if add_date:
+        df = (df.assign(date = lambda x: x.data_frame_ref))
+    
+    df[['date_recorded', 'time_recorded']] = df.time_recorded.str.split('T', expand=True)
+    df[['predicted_end_date', 'predicted_end_time']] = df.predicted_end_time.str.split('T', expand=True)
+    df[['planned_start_date', 'planned_start_time']] = df.planned_start_time.str.split('T', expand=True)
+    df = df[["timestamp", "agency_id",
+                  "route_id", "route_short_name", "service_id",
+                  "planned_start_date", "planned_start_time", "bus_id", "predicted_end_date", "predicted_end_time",
+                  "date_recorded", "time_recorded", "lat", "lon",
+                  "data_frame_ref", "stop_point_ref", "vehicle_at_stop",
+                  "log_version", "date"]]
+    return df
+
+
 def main(FOLDER,out_folder):
     if not os.path.exists(out_folder):
         os.mkdir(out_folder)
 
     for file in glob(FOLDER+'/*'):
         base = '.'.join(os.path.basename(file).split('.')[:-2])
+        version = re.match("siri_rt_data_([^\.]*)\.", os.path.basename(file)).groups()[0]
         out_path = os.path.join(out_folder, base+'.csv.gz')
         if not os.path.exists(out_path):
             #out_path = os.path.join(out_folder, base+'_FIXED.csv.gz')
             print(file)
             try:
-                df = create_trip_df(file, drop=['desc'], convert_timestr_to_seconds=False)
+                if version=='':
+                    df = create_trip_df(file, drop=['desc'], convert_timestr_to_seconds=False)
+                elif version=='v2':
+                    df = create_trip_df_v2(file)
             except Exception as e:
                 print(str(e))
             #df.to_parquet(bn + '.parq')


### PR DESCRIPTION
This addresses #237 . 
Adds a new function `create_trip_df_v2` that handles the new siri log (v2). It splits all datetime fields into separate date and time fields.
The main now checks the version of the log using a regex on the file name.

The `date` column in v2 is a replication of the `data_frame_ref` field (should hold the date of the relevant gtfs file. We should check that once we have many files in splunk.