### PR TITLE
#186 docs continuation

### DIFF
--- a/gtfs/docs/source/index.rst
+++ b/gtfs/docs/source/index.rst
@@ -18,6 +18,17 @@ Configuration
 | GTFS Utils requires a configuration file  ``config.json``.
 | An example file can be found in ``gtfs_utils/config_example.json``.
 
+bucket_valid_file_name_regexp
+.............................
+| Use ``bucket_valid_file_name_regexp`` field in configuration to choose which dates to run the script on.
+| You can use a value such as ``"2019-03-07.zip"`` to run on a single date, or ``"2019-05-\d\d\.zip"`` to run on a full
+  month, for example.
+
+forward_fill
+............
+Set ``forward_fill`` field in configuration to ``true`` for performing forward fill for missing dates using existing
+files.
+
 Output format
 -------------
 | GTFS Stats outputs stats for trips and for routes (`trip_stats` and `route_stats`, accordingly).
@@ -25,6 +36,10 @@ Output format
   `Pandas DataFrame <http://pandas.pydata.org/pandas-docs/stable/reference/frame.html>`_, and is located in the
   ``output`` directory, as defined in the configuration file.
 | The fields in each one of them are described in the output specifications below.
+
+Output format as it is in Splunk
+................................
+*This section will be written soon.*
 
 .. toctree::
    :caption: Output specifications

--- a/gtfs/docs/source/index.rst
+++ b/gtfs/docs/source/index.rst
@@ -1,14 +1,13 @@
 Open-Bus GTFS Utils
 ===================
 
-GTFS Utils is a utility for reading, parsing and aggregating GTFS data from Israel MOT.
-
-GTFS Utils is part of `Open-Bus <https://github.com/hasadna/open-bus>`_ project in \
-`The Public Knowledge Workshop ("הסדנה לידע ציבורי") <https://www.hasadna.org.il/>`_.
+| GTFS Utils is a utility for reading, parsing and aggregating GTFS data from Israel MOT.
+| GTFS Utils is part of `Open-Bus <https://github.com/hasadna/open-bus>`_ project in
+  `The Public Knowledge Workshop ("הסדנה לידע ציבורי") <https://www.hasadna.org.il/>`_.
 
 Usage
 -----
-To use GTFS Utils script, run:
+To use GTFS Stats script, run:
 
 .. code-block:: bash
 
@@ -16,12 +15,16 @@ To use GTFS Utils script, run:
 
 Configuration
 -------------
-To be written
+| GTFS Utils requires a configuration file  ``config.json``.
+| An example file can be found in ``gtfs_utils/config_example.json``.
 
 Output format
 -------------
-To be written
-
+| GTFS Stats outputs stats for trips and for routes (`trip_stats` and `route_stats`, accordingly).
+| Each of them is output as a ``pkl.gz`` file (a gzipped `pickle <https://docs.python.org/3/library/pickle.html>`_) of a
+  `Pandas DataFrame <http://pandas.pydata.org/pandas-docs/stable/reference/frame.html>`_, and is located in the
+  ``output`` directory, as defined in the configuration file.
+| The fields in each one of them are described in the output specifications below.
 
 .. toctree::
    :caption: Output specifications

--- a/gtfs/docs/source/index.rst
+++ b/gtfs/docs/source/index.rst
@@ -1,8 +1,30 @@
-Welcome to Open-Bus GTFS Utils documentation!
-=============================================
+Open-Bus GTFS Utils
+===================
+
+GTFS Utils is a utility for reading, parsing and aggregating GTFS data from Israel MOT.
+
+GTFS Utils is part of `Open-Bus <https://github.com/hasadna/open-bus>`_ project in \
+`The Public Knowledge Workshop ("הסדנה לידע ציבורי") <https://www.hasadna.org.il/>`_.
+
+Usage
+-----
+To use GTFS Utils script, run:
+
+.. code-block:: bash
+
+    python gtfs_utils/gtfs_stats.py
+
+Configuration
+-------------
+To be written
+
+Output format
+-------------
+To be written
+
 
 .. toctree::
-   :caption: Content
+   :caption: Output specifications
 
    trip_stats
    route_stats


### PR DESCRIPTION
I currently have an issue with building the docs (something with the imports, I'm going to solve it before closing #186).
The error is in the trip stats and route stats documentation pages, but you can still build the main page by running `make html` for Linux or `make.bat html` for Windows, or simply view the attached file: [Open-Bus GTFS Utils — gtfs documentation.pdf](https://github.com/hasadna/open-bus/files/3341761/Open-Bus.GTFS.Utils.gtfs.documentation.pdf)
