### PR TITLE
Bug/no config file on rtd

### DIFF
--- a/gtfs/gtfs_utils/gtfs_utils/configuration.py
+++ b/gtfs/gtfs_utils/gtfs_utils/configuration.py
@@ -137,7 +137,7 @@ def validate_configuration_schema(configuration_dict: dict) -> None:
     validate(instance=configuration_dict, schema=schema)
 
 
-@lru_cache
+@lru_cache()
 def load_configuration(config_path: str = CONFIGURATION_FILE_PATH) -> Configuration:
     with open(config_path, 'r') as configuration_file:
         configuration_dict = json.load(configuration_file)

--- a/gtfs/gtfs_utils/gtfs_utils/configuration.py
+++ b/gtfs/gtfs_utils/gtfs_utils/configuration.py
@@ -3,6 +3,7 @@ import os
 import re
 import sys
 from dataclasses import dataclass, fields, is_dataclass, field
+from functools import lru_cache
 from inspect import isclass
 from typing import Dict, List
 
@@ -136,11 +137,9 @@ def validate_configuration_schema(configuration_dict: dict) -> None:
     validate(instance=configuration_dict, schema=schema)
 
 
-def load_configuration() -> Configuration:
-    with open(CONFIGURATION_FILE_PATH, 'r') as configuration_file:
+@lru_cache
+def load_configuration(config_path: str = CONFIGURATION_FILE_PATH) -> Configuration:
+    with open(config_path, 'r') as configuration_file:
         configuration_dict = json.load(configuration_file)
     validate_configuration_schema(configuration_dict)
     return dict_to_dataclass(configuration_dict, Configuration)
-
-
-configuration = load_configuration()

--- a/gtfs/gtfs_utils/gtfs_utils/environment.py
+++ b/gtfs/gtfs_utils/gtfs_utils/environment.py
@@ -2,7 +2,7 @@ import ctypes
 import os
 import platform
 
-from .configuration import configuration
+from .configuration import load_configuration
 
 
 def mkdir_if_not_exists(dir_path):
@@ -13,6 +13,7 @@ def mkdir_if_not_exists(dir_path):
 
 def init_conf():
     """ Initializes directories from configuration file """
+    configuration = load_configuration()
     mkdir_if_not_exists(configuration.files.base_directory)
 
     for dir_path in configuration.files.full_paths.all():

--- a/gtfs/gtfs_utils/gtfs_utils/local_files.py
+++ b/gtfs/gtfs_utils/gtfs_utils/local_files.py
@@ -3,7 +3,7 @@ import re
 from os import listdir
 from os.path import split, join, exists
 from typing import Tuple, List
-from .configuration import configuration
+from .configuration import load_configuration
 
 
 def _get_existing_output_files(output_folder: str) -> List[Tuple[datetime.date, str]]:
@@ -15,6 +15,7 @@ def _get_existing_output_files(output_folder: str) -> List[Tuple[datetime.date, 
     if not exists(output_folder):
         return []
 
+    configuration = load_configuration()
     file_name_re = configuration.files.output_file_name_regexp
     file_type_re = configuration.files.output_file_type.replace('.', '\\.')
     regexp = file_name_re + '\\.' + file_type_re
@@ -50,6 +51,7 @@ def get_dates_without_output(dates: List[datetime.date], output_folder: str) -> 
 
 def remote_key_to_local_path(date: datetime.date, remote_key: str) -> str:
     local_file_name = split(remote_key)[-1]
+    configuration = load_configuration()
     local_full_path = join(configuration.files.full_paths.gtfs_feeds,
                            date.strftime('%Y-%m-%d'),
                            local_file_name)

--- a/gtfs/gtfs_utils/gtfs_utils/logging_config.py
+++ b/gtfs/gtfs_utils/gtfs_utils/logging_config.py
@@ -1,12 +1,13 @@
 import logging
 import os
 from datetime import datetime
-from .configuration import configuration
+from .configuration import load_configuration
 
 
 def configure_logger():
     root_logger = logging.getLogger()
     root_logger.setLevel(logging.DEBUG)
+    configuration = load_configuration()
 
     datetime_string = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
     log_file_name = f'gtfs_stats_{datetime_string}.log'

--- a/gtfs/gtfs_utils/gtfs_utils/output.py
+++ b/gtfs/gtfs_utils/gtfs_utils/output.py
@@ -1,6 +1,6 @@
 import logging
+
 import pandas as pd
-from .configuration import configuration
 
 
 def __extract_file_type(file_path: str):

--- a/gtfs/gtfs_utils/gtfs_utils/partridge_helper.py
+++ b/gtfs/gtfs_utils/gtfs_utils/partridge_helper.py
@@ -6,7 +6,7 @@ from os.path import join, basename
 import numpy as np
 import partridge as ptg
 
-from .configuration import configuration
+from .configuration import load_configuration
 
 
 def get_partridge_filter_for_date(zip_path: str, date: datetime.date):
@@ -29,7 +29,9 @@ def write_filtered_feed_by_date(zip_path: str, date: datetime.date, output_path:
 
 def prepare_partridge_feed(date: datetime.date,
                            gtfs_file_full_path: str,
-                           filtered_feeds_directory=configuration.files.full_paths.filtered_feeds):
+                           filtered_feeds_directory=None):
+    configuration = load_configuration()
+    filtered_feeds_directory = filtered_feeds_directory or configuration.files.full_paths.filtered_feeds
 
     if configuration.write_filtered_feed:
         filtered_gtfs_path = join(filtered_feeds_directory, basename(gtfs_file_full_path))

--- a/gtfs/gtfs_utils/gtfs_utils/s3.py
+++ b/gtfs/gtfs_utils/gtfs_utils/s3.py
@@ -5,7 +5,7 @@ from typing import List, Tuple, Union
 
 from tqdm import tqdm
 
-from .configuration import configuration
+from .configuration import load_configuration
 from .environment import get_free_space_bytes
 from .retry import retry
 from .s3_wrapper import list_content, S3Crud
@@ -22,6 +22,7 @@ Download file from s3 bucket. Retry using decorator.
     :param output_path: output path to download the file to
     :type output_path: str
     """
+    configuration = load_configuration()
 
     def hook(t):
         def inner(bytes_amount):
@@ -116,6 +117,7 @@ def validate_download_size(all_remote_keys: List[str], crud: S3Crud,
     :param crud: crud
     :return: the total size of the file, IOError if the files are to big
     """
+    configuration = load_configuration()
     if download_dir is None:
         download_dir = configuration.files.full_paths.gtfs_feeds
     free_space = get_free_space_bytes(download_dir)


### PR DESCRIPTION
A fix for the Read The Docs build problem
The problem was caused wince the documented file imported `configuration.py` and the import faild when it tried to read `config.json`
to prevent future problems with building documentation for scripts using `configuration.py` removed the call to `load_configuration` on import

I tried this methos to use travis to test the sphinx-build, but couldn't make it work
https://medium.com/akeneo-labs/documentation-on-steroids-with-sphinx-github-travis-ci-and-platform-sh-89218513d136